### PR TITLE
Add basic structure for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 .idea/
 gbdk/
+cpputest/
 
 # Prerequisites
 *.d
@@ -58,3 +59,8 @@ dkms.conf
 
 winehq.key
 .vscode
+
+# Coverage
+coverage/
+coverage.info
+main_tests

--- a/MakeGb.mk
+++ b/MakeGb.mk
@@ -1,34 +1,33 @@
-NOME_DO_JOGO=headhit
-ARQUIVO_GB=build/$(NOME_DO_JOGO).gb
+GAME_NAME=headhit
+GB_FILE=build/$(GAME_NAME).gb
 
-DIRETORIO_SOURCES=src
-DIRETORIO_OBJ=build
-MODULOS := vdata menu lib match
-DIRETORIOS_MODULOS := $(patsubst %, $(DIRETORIO_OBJ)/%, $(MODULOS))
+SOURCES_DIR=src
+OBJ_DIR=build
+MODULES := vdata menu lib match
+MODULES_DIR := $(patsubst %, $(OBJ_DIR)/%, $(MODULES))
 
-# ARQUIVOS_C=$(wildcard $(DIRETORIO_SOURCES)/*.c)
-ARQUIVOS_C=$(shell find $(DIRETORIO_SOURCES)/ -type f -name '*.c')
-ARQUIVOS_OBJ=$(patsubst $(DIRETORIO_SOURCES)/%.c, $(DIRETORIO_OBJ)/%.o, $(ARQUIVOS_C))
+C_FILES=$(shell find $(SOURCES_DIR)/ -type f -name '*.c')
+OBJ_FILES=$(patsubst $(SOURCES_DIR)/%.c, $(OBJ_DIR)/%.o, $(C_FILES))
 
-COMPILADOR=gbdk/bin/lcc
+CC=gbdk/bin/lcc
 
-FLAGS_DO_COMPILADOR=-Wa-l 				\
-					-Wl-m 				\
-					-Wf--debug 			\
-					-Wl-y 				\
-					-Wl-w 				\
-					-DUSE_SFR_FOR_REG
+FLAGS=	-Wa-l			\
+	-Wl-m 			\
+	-Wf--debug 		\
+	-Wl-y 			\
+	-Wl-w 			\
+	-DUSE_SFR_FOR_REG	\
 
-all: criar_diretorio_build $(ARQUIVO_GB)
+all: create_dir_build $(GB_FILE)
 
-$(ARQUIVO_GB): $(ARQUIVOS_OBJ)
-	$(COMPILADOR) $(FLAGS_DO_COMPILADOR) -o $(ARQUIVO_GB) $(ARQUIVOS_OBJ)
+$(GB_FILE): $(OBJ_FILES)
+	$(CC) $(FLAGS) -o $(GB_FILE) $(OBJ_FILES)
 
-$(DIRETORIO_OBJ)/%.o: $(DIRETORIO_SOURCES)/%.c
-	$(COMPILADOR) $(FLAGS_DO_COMPILADOR) -c -o $@ $<
+$(OBJ_DIR)/%.o: $(SOURCES_DIR)/%.c
+	$(CC) $(FLAGS) -c -o $@ $<
 
-criar_diretorio_build:
-	@ mkdir -p $(DIRETORIO_OBJ) $(DIRETORIOS_MODULOS)
+create_dir_build:
+	mkdir -p $(OBJ_DIR) $(MODULES_DIR)
 
 clean:
-	@ rm -rf $(DIRETORIO_OBJ)/*
+	rm -rf $(OBJ_DIR)/*

--- a/MakeTests.mk
+++ b/MakeTests.mk
@@ -1,0 +1,43 @@
+## CppUTest configurations ##
+# Read header comment on file `$(CPPUTEST_HOME)/build/MakefileWorker.mk` to understand these definitions.
+
+COMPONENT_NAME = main
+CPPUTEST_HOME = cpputest
+
+CPPUTEST_ENABLE_DEBUG = Y
+CPPUTEST_USE_EXTENSIONS = Y
+CPP_PLATFORM = Gcc
+CPPUTEST_USE_GCOV = Y
+CPPUTEST_OBJS_DIR = build/objs/tests
+CPPUTEST_LIB_DIR = build/lib/tests
+
+SRC_DIRS = \
+    libs
+
+TEST_SRC_DIRS = \
+    tests
+
+INCLUDE_DIRS = \
+    libs 			\
+    $(CPPUTEST_HOME)/include	\
+
+CPPUTEST_CPPFLAGS = -DDISABLE_LOG -DTEST_BUILD
+CPPUTEST_CXXFLAGS = -std=c++14 -O0
+CPPUTEST_LDFLAGS = -pthread
+CPPUTEST_WARNINGFLAGS = -Wall -Wextra -Wshadow -Wswitch-default -Wswitch-enum -Wconversion -Wno-long-long
+
+## The real work ##
+# including this file that will use configuration and have the make rules.
+include $(CPPUTEST_HOME)/build/MakefileWorker.mk
+
+# Coverage Report rules #
+coverage: all
+	$(SILENCE)lcov --capture --directory build/objs/tests/libs --output-file coverage.info
+	$(SILANCE)genhtml coverage.info --output-directory coverage
+	@echo
+	@echo "Written coverage report to coverage/index.html"
+	@echo
+
+coverage_clean:
+	rm -rf coverage coverage.info
+

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,52 @@
 .DEFAULT_GOAL := all
 
+.PHONY: help
+help:
+	@echo "$$(tput bold)Commands:$$(tput sgr0)"
+	@echo
+	@sed -n -e "/^## / { \
+		h; \
+		s/.*//; \
+		:doc" \
+		-e "H; \
+		n; \
+		s/^## //; \
+		t doc" \
+		-e "s/:.*//; \
+		G; \
+		s/\\n## /---/; \
+		s/\\n/ /g; \
+		p; \
+	}" ${MAKEFILE_LIST} \
+	| LC_ALL='C' sort --ignore-case \
+	| awk -F '---' \
+		-v ncol=$$(tput cols) \
+		-v indent=19 \
+		-v col_on="$$(tput setaf 6)" \
+		-v col_off="$$(tput sgr0)" \
+	'{ \
+		printf "%s%*s%s ", col_on, -indent, $$1, col_off; \
+		n = split($$2, words, " "); \
+		line_length = ncol - indent; \
+		for (i = 1; i <= n; i++) { \
+			line_length -= length(words[i]) + 1; \
+			if (line_length <= 0) { \
+				line_length = ncol - indent - length(words[i]) - 1; \
+				printf "\n%*s ", -indent, " "; \
+			} \
+			printf "%s ", words[i]; \
+		} \
+		printf "\n"; \
+	}' \
+	| more $(shell test $(shell uname) == Darwin && echo '--no-init --raw-control-chars')
+
 .PHONY: cgb
+## Compile sources to .gb file
 cgb:
 	@ make -f MakeGb.mk all
 
 .PHONY: download_gbdk
+## Download GBDK_2020 directly from github inside folder
 download_gbdk:
 	if [ -f /gbdk-linux64.tar.gz ]; then rm -rf gbdk-linux64.tar.gz; fi
 	wget https://github.com/gbdk-2020/gbdk-2020/releases/download/4.0.5/gbdk-linux64.tar.gz
@@ -12,12 +54,15 @@ download_gbdk:
 	rm gbdk-linux64.tar.gz
 
 .PHONY: play
+## Compile .gb file and emulate in emulator sameboy
 play:
 	make && sameboy build/*.gb
 
 .PHONY: clean
+## Call clean in all makefiles
 clean:
 	make -f MakeGb.mk clean
 
 .PHONY: all
+## Call rule cgb
 all: cgb

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,27 @@ download_gbdk:
 	tar -xf gbdk-linux64.tar.gz
 	rm gbdk-linux64.tar.gz
 
+.PHONY: download_cpputest
+## Download CppUTest v3.8 directly from github inside folder and compile
+download_cpputest:
+	if [ -d /cpputest-3.8 ]; then rm -rf cpputest-3.8 ; fi
+	if [ -f /cpputest-3.8.tar.gz ]; then rm -rf cpputest-3.8.tar.gz; fi
+	wget https://github.com/cpputest/cpputest/releases/download/v3.8/cpputest-3.8.tar.gz
+	tar -xf cpputest-3.8.tar.gz
+	rm cpputest-3.8.tar.gz
+	mv cpputest-3.8 cpputest
+	cd cpputest; ./autogen.sh; ./configure; make all
+
+.PHONY: tests
+## Run unit tests
+tests:
+	make -f MakeTests.mk all
+
+.PHONY: coverage
+## Generate test coverage of project
+coverage:
+	make -f MakeTests.mk coverage
+
 .PHONY: play
 ## Compile .gb file and emulate in emulator sameboy
 play:
@@ -62,7 +83,10 @@ play:
 ## Call clean in all makefiles
 clean:
 	make -f MakeGb.mk clean
+	make -f MakeTests.mk clean
+	make -f MakeTests.mk coverage_clean
 
 .PHONY: all
 ## Call rule cgb
 all: cgb
+

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,23 @@
-all: gb
+.DEFAULT_GOAL := all
 
-gb:
+.PHONY: cgb
+cgb:
 	@ make -f MakeGb.mk all
 
-baixar_gbdk:
+.PHONY: download_gbdk
+download_gbdk:
 	if [ -f /gbdk-linux64.tar.gz ]; then rm -rf gbdk-linux64.tar.gz; fi
 	wget https://github.com/gbdk-2020/gbdk-2020/releases/download/4.0.5/gbdk-linux64.tar.gz
 	tar -xf gbdk-linux64.tar.gz
 	rm gbdk-linux64.tar.gz
 
-rodar_jogo:
+.PHONY: play
+play:
 	make && sameboy build/*.gb
 
+.PHONY: clean
 clean:
 	make -f MakeGb.mk clean
+
+.PHONY: all
+all: cgb

--- a/libs/hello_world.c
+++ b/libs/hello_world.c
@@ -1,0 +1,6 @@
+#include "hello_world.h"
+
+char *hello_world(void)
+{
+	return "Koe!";
+}

--- a/libs/hello_world.h
+++ b/libs/hello_world.h
@@ -1,0 +1,6 @@
+#ifndef _H_TESTE
+#define _H_TESTE
+
+char *hello_world(void);
+
+#endif

--- a/tests/AllTests.cpp
+++ b/tests/AllTests.cpp
@@ -1,0 +1,6 @@
+#include <CppUTest/CommandLineTestRunner.h>
+
+int main(int ac, char** av)
+{
+	return CommandLineTestRunner::RunAllTests(ac, av);
+}

--- a/tests/ExampleTest.cpp
+++ b/tests/ExampleTest.cpp
@@ -1,0 +1,22 @@
+#include <CppUTest/TestHarness.h>
+
+extern "C"
+{
+	#include "../libs/hello_world.h"
+}
+
+TEST_GROUP(helloWorld)
+{
+	void setup()
+	{
+	}
+
+	void teardown()
+	{
+	}
+};
+
+TEST(helloWorld, test1)
+{
+	STRCMP_EQUAL("Koe!", hello_world());
+}


### PR DESCRIPTION
Changes:

- Translate Makefile to English;
- Improve Makefile as a command runner;
- Make `help` command fully automated;
- Add examples tests in folder `/tests` and example module in `/libs`.

The idea behind unit tests in embedded systems (yes, the game boy is an embedded system) is creating isolated modules that not depend on the platform been developed. So in the future I will create modules in `/libs` independent on the hardware and refactor the code in `src/` with these modules.